### PR TITLE
Update Graphql transaction list

### DIFF
--- a/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -36,12 +36,14 @@ public class ChuckerInterceptor private constructor(
 
     private val collector = builder.collector ?: ChuckerCollector(builder.context)
 
+    private val graphQLEndpoint = builder.graphQLEndpoint
+
     private val requestProcessor = RequestProcessor(
         builder.context,
         collector,
         builder.maxContentLength,
         headersToRedact,
-        decoders,
+        decoders
     )
 
     private val responseProcessor = ResponseProcessor(
@@ -50,7 +52,7 @@ public class ChuckerInterceptor private constructor(
         builder.maxContentLength,
         headersToRedact,
         builder.alwaysReadResponseBody,
-        decoders,
+        decoders
     )
 
     init {
@@ -69,7 +71,7 @@ public class ChuckerInterceptor private constructor(
         val transaction = HttpTransaction()
         val request = chain.request()
 
-        requestProcessor.process(request, transaction)
+        requestProcessor.process(request, transaction,graphQLEndpoint)
 
         val response = try {
             chain.proceed(request)
@@ -95,7 +97,7 @@ public class ChuckerInterceptor private constructor(
         internal var headersToRedact = emptySet<String>()
         internal var decoders = emptyList<BodyDecoder>()
         internal var createShortcut = true
-
+        internal var graphQLEndpoint = ""
         /**
          * Sets the [ChuckerCollector] to customize data retention.
          */
@@ -162,6 +164,10 @@ public class ChuckerInterceptor private constructor(
         @VisibleForTesting
         internal fun cacheDirectorProvider(provider: CacheDirectoryProvider): Builder = apply {
             this.cacheDirectoryProvider = provider
+        }
+
+        public fun graphQLEndpoint(graphQLEndpoint: String): Builder = apply {
+            this.graphQLEndpoint = graphQLEndpoint
         }
 
         /**

--- a/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -166,7 +166,10 @@ public class ChuckerInterceptor private constructor(
             this.cacheDirectoryProvider = provider
         }
 
-        public fun graphQLEndpoint(graphQLEndpoint: String): Builder = apply {
+        /**
+         * Sets graphql endpoint/path to identify graphql requests.
+         */
+        public fun registerGraphQLEndpoint(graphQLEndpoint: String): Builder = apply {
             this.graphQLEndpoint = graphQLEndpoint
         }
 

--- a/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -97,7 +97,7 @@ public class ChuckerInterceptor private constructor(
         internal var headersToRedact = emptySet<String>()
         internal var decoders = emptyList<BodyDecoder>()
         internal var createShortcut = true
-        internal var graphQLEndpoint = ""
+        internal var graphQLEndpoint = "------"
         /**
          * Sets the [ChuckerCollector] to customize data retention.
          */

--- a/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -52,7 +52,7 @@ public class ChuckerInterceptor private constructor(
         builder.maxContentLength,
         headersToRedact,
         builder.alwaysReadResponseBody,
-        decoders
+        decoders,
     )
 
     init {

--- a/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -97,7 +97,7 @@ public class ChuckerInterceptor private constructor(
         internal var headersToRedact = emptySet<String>()
         internal var decoders = emptyList<BodyDecoder>()
         internal var createShortcut = true
-        internal var graphQLEndpoint = "------"
+        internal var graphQLEndpoint: String? = null
         /**
          * Sets the [ChuckerCollector] to customize data retention.
          */

--- a/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/api/ChuckerInterceptor.kt
@@ -43,7 +43,7 @@ public class ChuckerInterceptor private constructor(
         collector,
         builder.maxContentLength,
         headersToRedact,
-        decoders
+        decoders,
     )
 
     private val responseProcessor = ResponseProcessor(
@@ -71,7 +71,7 @@ public class ChuckerInterceptor private constructor(
         val transaction = HttpTransaction()
         val request = chain.request()
 
-        requestProcessor.process(request, transaction,graphQLEndpoint)
+        requestProcessor.process(request, transaction, graphQLEndpoint)
 
         val response = try {
             chain.proceed(request)

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/entity/HttpTransaction.kt
@@ -53,7 +53,8 @@ internal class HttpTransaction(
     @ColumnInfo(name = "responseHeadersSize") var responseHeadersSize: Long?,
     @ColumnInfo(name = "responseBody") var responseBody: String?,
     @ColumnInfo(name = "isResponseBodyEncoded") var isResponseBodyEncoded: Boolean = false,
-    @ColumnInfo(name = "responseImageData") var responseImageData: ByteArray?
+    @ColumnInfo(name = "responseImageData") var responseImageData: ByteArray?,
+    @ColumnInfo(name = "isGraphQLRequest") var isGraphQLRequest: Boolean = false
 ) {
 
     @Ignore
@@ -285,6 +286,7 @@ internal class HttpTransaction(
             (responseHeadersSize == other.responseHeadersSize) &&
             (responseBody == other.responseBody) &&
             (isResponseBodyEncoded == other.isResponseBodyEncoded) &&
-            (responseImageData?.contentEquals(other.responseImageData ?: byteArrayOf()) != false)
+            (responseImageData?.contentEquals(other.responseImageData ?: byteArrayOf()) != false) &&
+            (isGraphQLRequest == other.isGraphQLRequest)
     }
 }

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTuple.kt
@@ -22,7 +22,8 @@ internal data class HttpTransactionTuple(
     @ColumnInfo(name = "responseCode") var responseCode: Int?,
     @ColumnInfo(name = "requestPayloadSize") var requestPayloadSize: Long?,
     @ColumnInfo(name = "responsePayloadSize") var responsePayloadSize: Long?,
-    @ColumnInfo(name = "error") var error: String?
+    @ColumnInfo(name = "error") var error: String?,
+    @ColumnInfo(name = "isGraphQLRequest") var isGraphQL: Boolean
 ) {
     val isSsl: Boolean get() = scheme.equals("https", ignoreCase = true)
 

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/ChuckerDatabase.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/ChuckerDatabase.kt
@@ -6,7 +6,7 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 
-@Database(entities = [HttpTransaction::class], version = 7, exportSchema = false)
+@Database(entities = [HttpTransaction::class], version = 8, exportSchema = false)
 internal abstract class ChuckerDatabase : RoomDatabase() {
 
     abstract fun transactionDao(): HttpTransactionDao

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDao.kt
@@ -14,14 +14,14 @@ internal interface HttpTransactionDao {
 
     @Query(
         "SELECT id, requestDate, tookMs, protocol, method, host, " +
-            "path, scheme, responseCode, requestPayloadSize, responsePayloadSize, error FROM " +
+            "path, scheme, responseCode, requestPayloadSize, responsePayloadSize, error, isGraphQLRequest FROM " +
             "transactions ORDER BY requestDate DESC"
     )
     fun getSortedTuples(): LiveData<List<HttpTransactionTuple>>
 
     @Query(
         "SELECT id, requestDate, tookMs, protocol, method, host, " +
-            "path, scheme, responseCode, requestPayloadSize, responsePayloadSize, error FROM " +
+            "path, scheme, responseCode, requestPayloadSize, responsePayloadSize, error, isGraphQLRequest FROM " +
             "transactions WHERE responseCode LIKE :codeQuery AND path LIKE :pathQuery " +
             "ORDER BY requestDate DESC"
     )

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/RequestProcessor.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/RequestProcessor.kt
@@ -5,6 +5,7 @@ import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.api.BodyDecoder
 import com.chuckerteam.chucker.api.ChuckerCollector
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
+import okhttp3.HttpUrl
 import okhttp3.Request
 import okio.Buffer
 import okio.ByteString
@@ -17,17 +18,21 @@ internal class RequestProcessor(
     private val headersToRedact: Set<String>,
     private val bodyDecoders: List<BodyDecoder>,
 ) {
-    fun process(request: Request, transaction: HttpTransaction) {
-        processMetadata(request, transaction)
+    fun process(request: Request, transaction: HttpTransaction, graphQLEndpoint: String) {
+        processMetadata(request, transaction,graphQLEndpoint)
         processPayload(request, transaction)
         collector.onRequestSent(transaction)
     }
 
-    private fun processMetadata(request: Request, transaction: HttpTransaction) {
+    private fun processMetadata(request: Request, transaction: HttpTransaction, graphQLEndpoint: String) {
         transaction.apply {
             requestHeadersSize = request.headers.byteCount()
             setRequestHeaders(request.headers.redact(headersToRedact))
             populateUrl(request.url)
+
+            if (graphQLEndpoint.isNotEmpty() && checkIfGraphQL(request.url, graphQLEndpoint)){
+                isGraphQLRequest = true
+            }
 
             requestDate = System.currentTimeMillis()
             method = request.method
@@ -35,6 +40,8 @@ internal class RequestProcessor(
             requestPayloadSize = request.body?.contentLength()
         }
     }
+
+    private fun checkIfGraphQL(url: HttpUrl, graphQLEndpoint: String) = url.toString().contains(graphQLEndpoint)
 
     private fun processPayload(request: Request, transaction: HttpTransaction) {
         val body = request.body ?: return

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/RequestProcessor.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/RequestProcessor.kt
@@ -5,7 +5,6 @@ import com.chuckerteam.chucker.R
 import com.chuckerteam.chucker.api.BodyDecoder
 import com.chuckerteam.chucker.api.ChuckerCollector
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
-import okhttp3.HttpUrl
 import okhttp3.Request
 import okio.Buffer
 import okio.ByteString
@@ -29,10 +28,7 @@ internal class RequestProcessor(
             requestHeadersSize = request.headers.byteCount()
             setRequestHeaders(request.headers.redact(headersToRedact))
             populateUrl(request.url)
-
-            if (graphQLEndpoint.isNotEmpty() && checkIfGraphQL(request.url, graphQLEndpoint)){
-                isGraphQLRequest = true
-            }
+            isGraphQLRequest = graphQLEndpoint.isNotEmpty() && url.toString().contains(graphQLEndpoint)
 
             requestDate = System.currentTimeMillis()
             method = request.method
@@ -40,8 +36,6 @@ internal class RequestProcessor(
             requestPayloadSize = request.body?.contentLength()
         }
     }
-
-    private fun checkIfGraphQL(url: HttpUrl, graphQLEndpoint: String) = url.toString().contains(graphQLEndpoint)
 
     private fun processPayload(request: Request, transaction: HttpTransaction) {
         val body = request.body ?: return

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/RequestProcessor.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/RequestProcessor.kt
@@ -17,18 +17,20 @@ internal class RequestProcessor(
     private val headersToRedact: Set<String>,
     private val bodyDecoders: List<BodyDecoder>,
 ) {
-    fun process(request: Request, transaction: HttpTransaction, graphQLEndpoint: String) {
+    fun process(request: Request, transaction: HttpTransaction, graphQLEndpoint: String?) {
         processMetadata(request, transaction, graphQLEndpoint)
         processPayload(request, transaction)
         collector.onRequestSent(transaction)
     }
 
-    private fun processMetadata(request: Request, transaction: HttpTransaction, graphQLEndpoint: String) {
+    private fun processMetadata(request: Request, transaction: HttpTransaction, graphQLEndpoint: String?) {
         transaction.apply {
             requestHeadersSize = request.headers.byteCount()
             setRequestHeaders(request.headers.redact(headersToRedact))
             populateUrl(request.url)
-            isGraphQLRequest = graphQLEndpoint.isNotEmpty() && url.toString().contains(graphQLEndpoint)
+            isGraphQLRequest = graphQLEndpoint?.let {
+                it.isNotEmpty() && url.toString().contains(it)
+            } ?: false
 
             requestDate = System.currentTimeMillis()
             method = request.method

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/RequestProcessor.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/support/RequestProcessor.kt
@@ -18,7 +18,7 @@ internal class RequestProcessor(
     private val bodyDecoders: List<BodyDecoder>,
 ) {
     fun process(request: Request, transaction: HttpTransaction, graphQLEndpoint: String) {
-        processMetadata(request, transaction,graphQLEndpoint)
+        processMetadata(request, transaction, graphQLEndpoint)
         processPayload(request, transaction)
         collector.onRequestSent(transaction)
     }

--- a/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
+++ b/library/src/main/kotlin/com/chuckerteam/chucker/internal/ui/transaction/TransactionAdapter.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.ColorStateList
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
@@ -62,6 +63,7 @@ internal class TransactionAdapter internal constructor(
                 timeStart.text = DateFormat.getTimeInstance().format(transaction.requestDate)
 
                 setProtocolImage(if (transaction.isSsl) ProtocolResources.Https() else ProtocolResources.Http())
+                graphql.visibility =  if(transaction.isGraphQL ) View.VISIBLE else View.INVISIBLE
 
                 if (transaction.status === HttpTransaction.Status.Complete) {
                     code.text = transaction.responseCode.toString()

--- a/library/src/main/res/drawable/chucker_ic_graphql_logo.xml
+++ b/library/src/main/res/drawable/chucker_ic_graphql_logo.xml
@@ -1,0 +1,18 @@
+<vector android:height="200dp" android:viewportHeight="400"
+    android:viewportWidth="400" android:width="200dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#E535AB" android:pathData="M57.47,302.66l-14.38,-8.3l160.15,-277.38l14.38,8.3z"/>
+    <path android:fillColor="#E535AB" android:pathData="M39.8,272.2h320.3v16.6h-320.3z"/>
+    <path android:fillColor="#E535AB" android:pathData="M206.35,374.03l-160.21,-92.5l8.3,-14.38l160.21,92.5z"/>
+    <path android:fillColor="#E535AB" android:pathData="M345.52,132.95l-160.21,-92.5l8.3,-14.38l160.21,92.5z"/>
+    <path android:fillColor="#E535AB" android:pathData="M54.48,132.88l-8.3,-14.38l160.21,-92.5l8.3,14.38z"/>
+    <path android:fillColor="#E535AB" android:pathData="M342.57,302.66l-160.15,-277.38l14.38,-8.3l160.15,277.38z"/>
+    <path android:fillColor="#E535AB" android:pathData="M52.5,107.5h16.6v185h-16.6z"/>
+    <path android:fillColor="#E535AB" android:pathData="M330.9,107.5h16.6v185h-16.6z"/>
+    <path android:fillColor="#E535AB" android:pathData="M203.52,367l-7.25,-12.56l139.34,-80.45l7.25,12.56z"/>
+    <path android:fillColor="#E535AB" android:pathData="M369.5,297.9c-9.6,16.7 -31,22.4 -47.7,12.8c-16.7,-9.6 -22.4,-31 -12.8,-47.7c9.6,-16.7 31,-22.4 47.7,-12.8C373.5,259.9 379.2,281.2 369.5,297.9"/>
+    <path android:fillColor="#E535AB" android:pathData="M90.9,137c-9.6,16.7 -31,22.4 -47.7,12.8c-16.7,-9.6 -22.4,-31 -12.8,-47.7c9.6,-16.7 31,-22.4 47.7,-12.8C94.8,99 100.5,120.3 90.9,137"/>
+    <path android:fillColor="#E535AB" android:pathData="M30.5,297.9c-9.6,-16.7 -3.9,-38 12.8,-47.7c16.7,-9.6 38,-3.9 47.7,12.8c9.6,16.7 3.9,38 -12.8,47.7C61.4,320.3 40.1,314.6 30.5,297.9"/>
+    <path android:fillColor="#E535AB" android:pathData="M309.1,137c-9.6,-16.7 -3.9,-38 12.8,-47.7c16.7,-9.6 38,-3.9 47.7,12.8c9.6,16.7 3.9,38 -12.8,47.7C340.1,159.4 318.7,153.7 309.1,137"/>
+    <path android:fillColor="#E535AB" android:pathData="M200,395.8c-19.3,0 -34.9,-15.6 -34.9,-34.9c0,-19.3 15.6,-34.9 34.9,-34.9c19.3,0 34.9,15.6 34.9,34.9C234.9,380.1 219.3,395.8 200,395.8"/>
+    <path android:fillColor="#E535AB" android:pathData="M200,74c-19.3,0 -34.9,-15.6 -34.9,-34.9c0,-19.3 15.6,-34.9 34.9,-34.9c19.3,0 34.9,15.6 34.9,34.9C234.9,58.4 219.3,74 200,74"/>
+</vector>

--- a/library/src/main/res/layout/chucker_list_item_transaction.xml
+++ b/library/src/main/res/layout/chucker_list_item_transaction.xml
@@ -13,7 +13,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_end="197dp" />
+        app:layout_constraintGuide_percent="0.5" />
 
     <TextView
         android:id="@+id/code"

--- a/library/src/main/res/layout/chucker_list_item_transaction.xml
+++ b/library/src/main/res/layout/chucker_list_item_transaction.xml
@@ -13,7 +13,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.5" />
+        app:layout_constraintGuide_end="197dp" />
 
     <TextView
         android:id="@+id/code"
@@ -68,7 +68,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toStartOf="@+id/duration"
-        app:layout_constraintStart_toStartOf="@+id/path"
+        app:layout_constraintStart_toStartOf="@+id/host"
         app:layout_constraintTop_toBottomOf="@+id/host"
         tools:text="18:29:07 PM" />
 
@@ -87,8 +87,19 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="end"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/host"
         app:layout_constraintStart_toEndOf="@+id/duration"
         app:layout_constraintTop_toTopOf="@+id/duration"
         tools:text="16.45 KB" />
+
+    <ImageView
+        android:id="@+id/graphql"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:contentDescription="@string/chucker_graphql"
+        app:layout_constraintBottom_toBottomOf="@+id/timeStart"
+        app:layout_constraintEnd_toEndOf="@+id/ssl"
+        app:layout_constraintStart_toStartOf="@+id/ssl"
+        app:layout_constraintTop_toTopOf="@+id/timeStart"
+        app:srcCompat="@drawable/chucker_ic_graphql_logo" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -58,4 +58,5 @@
     <string name="chucker_request_is_empty">This request is empty</string>
     <string name="chucker_response_is_empty">This response is empty</string>
     <string name="chucker_shortcut_label">Open Chucker</string>
+    <string name="chucker_graphql">GraphQL</string>
 </resources>

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTupleTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/entity/HttpTransactionTupleTest.kt
@@ -106,6 +106,16 @@ internal class HttpTransactionTupleTest {
             .isEqualTo("")
     }
 
+    @Test
+    fun `transaction is GraphQL`() {
+        assertThat(createTuple(isGraphQLRequest = true).isGraphQL).isTrue()
+    }
+
+    @Test
+    fun `transaction is not GraphQL`() {
+        assertThat(createTuple().isGraphQL).isFalse()
+    }
+
     private fun createTuple(
         id: Long = 0,
         requestDate: Long? = null,
@@ -118,7 +128,8 @@ internal class HttpTransactionTupleTest {
         responseCode: Int? = null,
         requestPayloadSize: Long? = null,
         responsePayloadSize: Long? = null,
-        error: String? = null
+        error: String? = null,
+        isGraphQLRequest: Boolean = false
     ) = HttpTransactionTuple(
         id,
         requestDate,
@@ -131,6 +142,7 @@ internal class HttpTransactionTupleTest {
         responseCode,
         requestPayloadSize,
         responsePayloadSize,
-        error
+        error,
+        isGraphQLRequest
     )
 }

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
@@ -68,7 +68,7 @@ internal class HttpTransactionDaoTest {
             assertThat(stringValue("responseMessage")).isEqualTo(data.responseMessage)
             assertThat(stringValue("responseBody")).isEqualTo(data.responseBody)
             assertThat(stringValue("error")).isEqualTo(data.error)
-            assertThat(stringValue("isGraphQLRequest")).isEqualTo(data.isGraphQLRequest)
+            assertThat(longValue("isGraphQLRequest")).isEqualTo(if(data.isGraphQLRequest) 1 else 0)
         }
     }
 

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/data/room/HttpTransactionDaoTest.kt
@@ -68,6 +68,7 @@ internal class HttpTransactionDaoTest {
             assertThat(stringValue("responseMessage")).isEqualTo(data.responseMessage)
             assertThat(stringValue("responseBody")).isEqualTo(data.responseBody)
             assertThat(stringValue("error")).isEqualTo(data.error)
+            assertThat(stringValue("isGraphQLRequest")).isEqualTo(data.isGraphQLRequest)
         }
     }
 

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/support/RequestProcessorTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/support/RequestProcessorTest.kt
@@ -36,7 +36,7 @@ internal class RequestProcessorTest {
     @Test
     fun `Given a GraphQL Url path WHEN process request THEN transaction is GraphQLRequest`() {
         val transaction = HttpTransaction()
-        val graphQLUrl = getGraphQLUrl(graphQLPath)
+        val graphQLUrl = getUrl(graphQLPath)
 
         val request: Request = mockk(relaxed = true) {
             every{ url } returns graphQLUrl
@@ -49,7 +49,7 @@ internal class RequestProcessorTest {
     @Test
     fun `Given an Url with no GraphQL path WHEN process request THEN transaction is NOT GraphQLRequest`() {
         val transaction = HttpTransaction()
-        val urlWithNoGraphQLPath = getNonGraphQLUrl()
+        val urlWithNoGraphQLPath = getUrl()
         val request:Request = mockk(relaxed = true) {
             every { url } returns urlWithNoGraphQLPath
         }
@@ -59,16 +59,10 @@ internal class RequestProcessorTest {
 
     }
 
-    private fun getGraphQLUrl(graphQLPath: String) =  HttpUrl.Builder()
+    private fun getUrl(graphQLPath: String? = null) =  HttpUrl.Builder()
         .scheme("https")
         .host("random_host")
-        .addPathSegment(graphQLPath)
-        .build()
-
-    private fun getNonGraphQLUrl() = HttpUrl.Builder()
-        .scheme("https")
-        .host("random_host")
-        .addPathSegment("some/other/path")
+        .addPathSegment(graphQLPath ?: "some/other/path")
         .build()
 
 }

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/support/RequestProcessorTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/support/RequestProcessorTest.kt
@@ -1,0 +1,75 @@
+package com.chuckerteam.chucker.internal.support
+
+import android.content.Context
+import com.chuckerteam.chucker.api.BodyDecoder
+import com.chuckerteam.chucker.api.ChuckerCollector
+import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
+import io.mockk.every
+import io.mockk.mockk
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.Request
+import okhttp3.RequestBody
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+
+internal class RequestProcessorTest {
+    private val context: Context = mockk()
+    private val chuckerCollector: ChuckerCollector = mockk(relaxed = true)
+    private val maxContentLength: Long = 0
+    private val headersToRedact: Set<String> = emptySet()
+    private val bodyDecoders: List<BodyDecoder> = emptyList()
+
+    private val blankGraphQLPath = "----"
+    private val graphQLPath = "graphql"
+
+    private val requestProcessor: RequestProcessor = RequestProcessor(
+        context = context,
+        collector = chuckerCollector,
+        maxContentLength = maxContentLength,
+        headersToRedact = headersToRedact,
+        bodyDecoders = bodyDecoders,
+    )
+
+
+    @Test
+    fun `Given a GraphQL Url path WHEN process request THEN transaction is GraphQLRequest`() {
+        val transaction = HttpTransaction()
+        val graphQLUrl = getGraphQLUrl(graphQLPath)
+
+        val request: Request = mockk(relaxed = true) {
+            every{ url } returns graphQLUrl
+        }
+        requestProcessor.process(request,transaction,graphQLPath)
+        assertTrue(transaction.isGraphQLRequest)
+
+    }
+
+    @Test
+    fun `Given an Url with no GraphQL path WHEN process request THEN transaction is NOT GraphQLRequest`() {
+        val transaction = HttpTransaction()
+        val urlWithNoGraphQLPath = getNonGraphQLUrl()
+        val request:Request = mockk(relaxed = true) {
+            every { url } returns urlWithNoGraphQLPath
+        }
+
+        requestProcessor.process(request,transaction,blankGraphQLPath)
+        assertFalse(transaction.isGraphQLRequest)
+
+    }
+
+    private fun getGraphQLUrl(graphQLPath: String) =  HttpUrl.Builder()
+        .scheme("https")
+        .host("random_host")
+        .addPathSegment(graphQLPath)
+        .build()
+
+    private fun getNonGraphQLUrl() = HttpUrl.Builder()
+        .scheme("https")
+        .host("random_host")
+        .addPathSegment("some/other/path")
+        .build()
+
+}
+

--- a/library/src/test/kotlin/com/chuckerteam/chucker/internal/support/RequestProcessorTest.kt
+++ b/library/src/test/kotlin/com/chuckerteam/chucker/internal/support/RequestProcessorTest.kt
@@ -6,10 +6,8 @@ import com.chuckerteam.chucker.api.ChuckerCollector
 import com.chuckerteam.chucker.internal.data.entity.HttpTransaction
 import io.mockk.every
 import io.mockk.mockk
-import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.Request
-import okhttp3.RequestBody
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -21,7 +19,6 @@ internal class RequestProcessorTest {
     private val headersToRedact: Set<String> = emptySet()
     private val bodyDecoders: List<BodyDecoder> = emptyList()
 
-    private val blankGraphQLPath = "----"
     private val graphQLPath = "graphql"
 
     private val requestProcessor: RequestProcessor = RequestProcessor(
@@ -54,9 +51,36 @@ internal class RequestProcessorTest {
             every { url } returns urlWithNoGraphQLPath
         }
 
-        requestProcessor.process(request,transaction,blankGraphQLPath)
+        requestProcessor.process(request,transaction,null)
         assertFalse(transaction.isGraphQLRequest)
 
+    }
+
+    @Test
+    fun `Given an empty GraphQL path WHEN process request THEN transaction is NOT GraphQLRequest`() {
+        val transaction = HttpTransaction()
+        val emptyPath = ""
+        val urlWithEmptyGraphQLPath = getUrl(emptyPath)
+        val request: Request = mockk(relaxed = true) {
+            every { url } returns urlWithEmptyGraphQLPath
+        }
+
+        requestProcessor.process(request,transaction,emptyPath)
+        assertFalse(transaction.isGraphQLRequest)
+    }
+
+
+    @Test
+    fun `Given a blank GraphQL path WHEN process request THEN transaction is NOT GraphQLPath`() {
+        val transaction = HttpTransaction()
+        val blankPath = "     "
+        val urlWithEmptyGraphQLPath = getUrl(blankPath)
+        val request: Request = mockk(relaxed = true) {
+            every { url } returns urlWithEmptyGraphQLPath
+        }
+
+        requestProcessor.process(request,transaction,blankPath)
+        assertFalse(transaction.isGraphQLRequest)
     }
 
     private fun getUrl(graphQLPath: String? = null) =  HttpUrl.Builder()

--- a/sample/src/main/kotlin/com/chuckerteam/chucker/sample/GraphQLTaskImpl.kt
+++ b/sample/src/main/kotlin/com/chuckerteam/chucker/sample/GraphQLTaskImpl.kt
@@ -1,7 +1,11 @@
 package com.chuckerteam.chucker.sample
 
 import okhttp3.OkHttpClient
-import retrofit2.*
+import retrofit2.Retrofit
+import retrofit2.Callback
+import retrofit2.Call
+import retrofit2.Response
+import retrofit2.create
 import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -9,6 +13,7 @@ import retrofit2.http.POST
 import retrofit2.http.Query
 
 const val GRAPHQL_BASE_URL = "https://rickandmortyapi.com/"
+private const val CHARACTER_ID = 6L
 class GraphQLTaskImpl(client: OkHttpClient):IGraphQLTask {
     private val api = Retrofit.Builder()
         .baseUrl(GRAPHQL_BASE_URL)
@@ -24,12 +29,13 @@ class GraphQLTaskImpl(client: OkHttpClient):IGraphQLTask {
             t.printStackTrace()
         }
     }
+
     override fun run(query: String, variables: String?) = with(api) {
         getCharacterById(query, variables).enqueue(noOpCallback)
         getCharacterByIdPost(
             GraphQLQuery(
             "query GetCharacter( \$id: ID! ){character(id:\$id) {id:id,      name,status     }}",
-            GraphQLVariables(6L)
+            GraphQLVariables(CHARACTER_ID)
             )
         ).enqueue(noOpCallback)
 

--- a/sample/src/main/kotlin/com/chuckerteam/chucker/sample/GraphQLTaskImpl.kt
+++ b/sample/src/main/kotlin/com/chuckerteam/chucker/sample/GraphQLTaskImpl.kt
@@ -1,0 +1,48 @@
+package com.chuckerteam.chucker.sample
+
+import okhttp3.OkHttpClient
+import retrofit2.*
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+const val GRAPHQL_BASE_URL = "https://rickandmortyapi.com/"
+class GraphQLTaskImpl(client: OkHttpClient):IGraphQLTask {
+    private val api = Retrofit.Builder()
+        .baseUrl(GRAPHQL_BASE_URL)
+        .addConverterFactory(GsonConverterFactory.create())
+        .client(client)
+        .build()
+        .create<Api>()
+
+    private val noOpCallback = object : Callback<Any?> {
+        override fun onResponse(call: Call<Any?>, response: Response<Any?>) = Unit
+
+        override fun onFailure(call: Call<Any?>, t: Throwable) {
+            t.printStackTrace()
+        }
+    }
+    override fun run(query: String, variables: String?) = with(api) {
+        getCharacterById(query, variables).enqueue(noOpCallback)
+        getCharacterByIdPost(
+            GraphQLQuery(
+            "query GetCharacter( \$id: ID! ){character(id:\$id) {id:id,      name,status     }}",
+            GraphQLVariables(6L)
+            )
+        ).enqueue(noOpCallback)
+
+    }
+
+    private interface Api {
+        @GET("graphql")
+        fun getCharacterById(@Query("query")query: String, @Query("variables") variables: String? = null ): Call<Any?>
+
+        @POST("graphql")
+        fun getCharacterByIdPost(@Body graphQLQuery: GraphQLQuery): Call<Any?>
+    }
+
+    data class GraphQLQuery(val query:String, val variables: GraphQLVariables)
+    data class GraphQLVariables(val id: Long)
+}

--- a/sample/src/main/kotlin/com/chuckerteam/chucker/sample/IGraphQLTask.kt
+++ b/sample/src/main/kotlin/com/chuckerteam/chucker/sample/IGraphQLTask.kt
@@ -1,0 +1,5 @@
+package com.chuckerteam.chucker.sample
+
+interface IGraphQLTask {
+    fun run(query: String, variables: String? = null)
+}

--- a/sample/src/main/kotlin/com/chuckerteam/chucker/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/com/chuckerteam/chucker/sample/MainActivity.kt
@@ -41,14 +41,8 @@ class MainActivity : AppCompatActivity() {
 
             doGraphql?.setOnClickListener {
                 for(task in graphQLTasks) {
-                    task.run("query GetCharacter( \$id: ID! ){\n" +
-                        "  character(id:\$id) {\n" +
-                        "      id:id,      \n" +
-                        "     \tname,\n" +
-                        "      status     \n" +
-                        "    \n" +
-                        "  }\n" +
-                        "}",
+                    task.run(
+                        GRAPHQL_QUERY,
                         "{\"id\":1}"
                     )
                 }

--- a/sample/src/main/kotlin/com/chuckerteam/chucker/sample/MainActivity.kt
+++ b/sample/src/main/kotlin/com/chuckerteam/chucker/sample/MainActivity.kt
@@ -22,6 +22,10 @@ class MainActivity : AppCompatActivity() {
         listOf(HttpBinHttpTask(client), DummyImageHttpTask(client), PostmanEchoHttpTask(client))
     }
 
+    private val graphQLTasks by lazy {
+        listOf(GraphQLTaskImpl(client),)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -32,6 +36,21 @@ class MainActivity : AppCompatActivity() {
             doHttp.setOnClickListener {
                 for (task in httpTasks) {
                     task.run()
+                }
+            }
+
+            doGraphql?.setOnClickListener {
+                for(task in graphQLTasks) {
+                    task.run("query GetCharacter( \$id: ID! ){\n" +
+                        "  character(id:\$id) {\n" +
+                        "      id:id,      \n" +
+                        "     \tname,\n" +
+                        "      status     \n" +
+                        "    \n" +
+                        "  }\n" +
+                        "}",
+                        "{\"id\":1}"
+                    )
                 }
             }
 

--- a/sample/src/main/kotlin/com/chuckerteam/chucker/sample/OkHttpUtils.kt
+++ b/sample/src/main/kotlin/com/chuckerteam/chucker/sample/OkHttpUtils.kt
@@ -30,7 +30,7 @@ fun createOkHttpClient(
         .redactHeaders(emptySet())
         .alwaysReadResponseBody(false)
         .addBodyDecoder(PokemonProtoBodyDecoder())
-        .graphQLEndpoint(GRAPHQL_BASE_URL)
+        .registerGraphQLEndpoint(GRAPHQL_BASE_URL)
         .build()
 
     return OkHttpClient.Builder()

--- a/sample/src/main/kotlin/com/chuckerteam/chucker/sample/OkHttpUtils.kt
+++ b/sample/src/main/kotlin/com/chuckerteam/chucker/sample/OkHttpUtils.kt
@@ -30,6 +30,7 @@ fun createOkHttpClient(
         .redactHeaders(emptySet())
         .alwaysReadResponseBody(false)
         .addBodyDecoder(PokemonProtoBodyDecoder())
+        .graphQLEndpoint(GRAPHQL_BASE_URL)
         .build()
 
     return OkHttpClient.Builder()

--- a/sample/src/main/res/layout/activity_main_sample.xml
+++ b/sample/src/main/res/layout/activity_main_sample.xml
@@ -81,12 +81,21 @@
         android:id="@+id/do_http"
         android:layout_width="0dp"
         android:layout_height="?attr/actionBarSize"
-        android:layout_marginBottom="@dimen/doub_grid_size"
         android:text="@string/do_http_activity"
-        app:layout_constraintBottom_toTopOf="@+id/launch_chucker_directly"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/interceptor_type_group"
+        app:layout_constraintWidth_max="@dimen/max_width" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/do_graphql"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        android:text="@string/do_graphql_activity"
+        app:layout_constraintBottom_toTopOf="@+id/launch_chucker_directly"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/do_http"
         app:layout_constraintWidth_max="@dimen/max_width" />
 
     <com.google.android.material.button.MaterialButton
@@ -97,7 +106,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/do_http"
+        app:layout_constraintTop_toBottomOf="@+id/interceptor_type_group"
         app:layout_constraintWidth_max="@dimen/max_width" />
 
     <androidx.constraintlayout.widget.Guideline

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="application_type">Application</string>
     <string name="network_type">Network</string>
     <string name="do_http_activity">Do HTTP activity</string>
+    <string name="do_graphql_activity">Do GraphQL activity</string>
     <string name="launch_chucker_directly">Launch Chucker directly</string>
 
     <string name="intro_title">Welcome to Chucker Sample App</string>


### PR DESCRIPTION
## :camera: Screenshots
<!-- Show us what you've changed, we love images. -->

## :page_facing_up: Context
Issue [#116](https://github.com/ChuckerTeam/chucker/issues/116) talks about the shortcoming of the [initial approach](https://github.com/ChuckerTeam/chucker/pull/70) of supporting GraphQL on Chucker.

This PR is an attempt support GraphQL on Chucker using the guidelines mentioned in Issue #116.

## :pencil: Changes

1. Enable clients to set a `graphQLEndpoint` through the `Chucker.Builder`
2. Pass the `graphQLEndpoint` as an argument to the `RequestProcessor.process(..)` method
3. Add `isGraphQLRequest` property in the `HttpTransaction` entity & `HttpTransactionTuple`
4. Expose `isGraphQLRequest` via `HttpTransactionTuple`
5. Tests
6. Update Sample app to illustrate the effects of the change.

<!-- If your changes affect users somehow, be it a new feature, a bugfix or an API change please update the `Unreleased` section in the CHANGELOG.md file. -->

## :paperclip: Related PR
PR[#805](https://github.com/ChuckerTeam/chucker/pull/805) is also doing the same thing but does not handle GraphQL requests via HTTP GET methods. But this PR does not block any other PR.

## :no_entry_sign: Breaking
<!-- Is there something breaking the API? Any class or method signature changed? --> 

1. `ChuckerInterceptor` now contains an additional parameter to represent a GraphQL path or url
2. `RequestProcessor`'s `process(..)` method would accept the Graphql path passed by Interceptor.

## :hammer_and_wrench: How to test
<!-- Is there a special case to test your changes? -->
Test cases for `RequestProcessor` included in the PR.
![chucker_update_transaction_list](https://user-images.githubusercontent.com/97124666/178785469-86ea0419-1d5d-4f27-97b6-62d4eecc1d55.gif)

## :stopwatch: Next steps
<!-- Do we have to plan something else after the merge? -->
